### PR TITLE
PN-20985: freeze courtesy channels at dispatch so address changes dur…

### DIFF
--- a/src/main/java/it/pagopa/pn/deliverypushworkflow/action/courtesymessage/SendCourtesyMessageHandler.java
+++ b/src/main/java/it/pagopa/pn/deliverypushworkflow/action/courtesymessage/SendCourtesyMessageHandler.java
@@ -65,7 +65,8 @@ public class SendCourtesyMessageHandler {
 
         CourtesyDigitalAddressInt courtesyAddress = resolveCourtesyAddress(notification, recIndex, channel);
         if (courtesyAddress == null) {
-            log.warn("Courtesy address not found for channel={}, channel closed - iun={} id={}", channel, iun, recIndex);
+            log.warn("Courtesy address not found for channel={}, closing channel - iun={} id={}", channel, iun, recIndex);
+            closeCourtesyChannelWithoutSuccess(notification, recIndex, details, CourtesyChannelFailureReasonInt.EXPECTED_FAILURE);
             return;
         }
 
@@ -114,6 +115,7 @@ public class SendCourtesyMessageHandler {
                 .channel(channel)
                 .retryIndex(nextRetryIndex)
                 .deliveryMode(details.getDeliveryMode())
+                .plannedChannels(details.getPlannedChannels())
                 .build();
         log.info("Rescheduling SEND_COURTESY_MESSAGE_ACTION channel={} nextRetryIndex={} waitMinutes={} schedulingDate={} - iun={} id={}",
                 channel, nextRetryIndex, waitMinutes, schedulingDate, iun, recIndex);
@@ -140,7 +142,7 @@ public class SendCourtesyMessageHandler {
     private void closeCourtesyChannelWithoutSuccess(NotificationInt notification, Integer recIndex, SendCourtesyMessageActionDetails details, CourtesyChannelFailureReasonInt failureReason) {
         addCourtesyChannelFailedToTimeline(notification, recIndex, details, failureReason);
         if (details.getDeliveryMode() == DeliveryModeInt.ANALOG) {
-            scheduleAnalogWorkflowIfAllChannelsClosedWithoutSuccess(notification, recIndex);
+            scheduleAnalogWorkflowIfAllChannelsClosedWithoutSuccess(notification, recIndex, details.getPlannedChannels());
         }
     }
 
@@ -155,13 +157,15 @@ public class SendCourtesyMessageHandler {
     /**
      * ANALOG coordination via strongly consistent reads: if every channel is now closed with no delivery, schedule
      * ANALOG_WORKFLOW immediately; a delivered channel keeps the +waiting scheduling and wins. Idempotent through the
-     * deterministic ANALOG_WORKFLOW actionId, so concurrent closures start it once.
+     * deterministic ANALOG_WORKFLOW actionId, so concurrent closures start it once. The expected channels are the set
+     * frozen at dispatch (carried in the action), so adding or removing a courtesy address during the retry window
+     * cannot alter the coordination and block the notification.
      */
-    private void scheduleAnalogWorkflowIfAllChannelsClosedWithoutSuccess(NotificationInt notification, Integer recIndex) {
+    private void scheduleAnalogWorkflowIfAllChannelsClosedWithoutSuccess(NotificationInt notification, Integer recIndex,
+                                                                         List<CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT> plannedChannels) {
         final String iun = notification.getIun();
         boolean anySuccess = false;
-        for (CourtesyDigitalAddressInt courtesyAddress : courtesyMessageUtils.getCourtesyAddresses(notification, recIndex)) {
-            CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT channel = courtesyAddress.getType();
+        for (CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT channel : plannedChannels) {
             if (isCourtesyChannelDelivered(iun, recIndex, channel)) {
                 anySuccess = true;
             } else if (!isCourtesyChannelFailedForAnalog(iun, recIndex, channel)) {

--- a/src/main/java/it/pagopa/pn/deliverypushworkflow/action/details/SendCourtesyMessageActionDetails.java
+++ b/src/main/java/it/pagopa/pn/deliverypushworkflow/action/details/SendCourtesyMessageActionDetails.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -16,4 +18,5 @@ public class SendCourtesyMessageActionDetails implements ActionDetails {
     private CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT channel;
     private int retryIndex;
     private DeliveryModeInt deliveryMode;
+    private List<CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT> plannedChannels;
 }

--- a/src/main/java/it/pagopa/pn/deliverypushworkflow/action/utils/CourtesyMessageUtils.java
+++ b/src/main/java/it/pagopa/pn/deliverypushworkflow/action/utils/CourtesyMessageUtils.java
@@ -45,12 +45,16 @@ public class CourtesyMessageUtils {
         log.debug("Start dispatchCourtesyMessagesActions - iun={} id={} delivery mode={} ", iun, recIndex, deliveryMode);
 
         List<CourtesyDigitalAddressInt> listCourtesyAddresses = getCourtesyAddresses(notification, recIndex);
+        List<CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT> plannedChannels = listCourtesyAddresses.stream()
+                .map(CourtesyDigitalAddressInt::getType)
+                .toList();
 
         for (CourtesyDigitalAddressInt courtesyAddress : listCourtesyAddresses) {
             SendCourtesyMessageActionDetails details = SendCourtesyMessageActionDetails.builder()
                     .channel(courtesyAddress.getType())
                     .retryIndex(0)
                     .deliveryMode(deliveryMode)
+                    .plannedChannels(plannedChannels)
                     .build();
             log.info("Scheduling SEND_COURTESY_MESSAGE_ACTION channel={} retryIndex=0 deliveryMode={} - iun={} id={}", courtesyAddress.getType(), deliveryMode, iun, recIndex);
             schedulerService.scheduleEvent(iun, recIndex, Instant.now(), ActionType.SEND_COURTESY_MESSAGE_ACTION, details);

--- a/src/test/java/it/pagopa/pn/deliverypushworkflow/action/courtesymessage/SendCourtesyMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/deliverypushworkflow/action/courtesymessage/SendCourtesyMessageHandlerTest.java
@@ -373,9 +373,13 @@ class SendCourtesyMessageHandlerTest {
         //WHEN
         sendCourtesyMessageHandler.handleSendCourtesyMessageAction(notification.getIun(), 0, details(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, DeliveryModeInt.ANALOG));
 
-        //THEN
+        //THEN - indirizzo non risolvibile: nessun invio, ma il canale viene chiuso con EXPECTED_FAILURE
         Mockito.verifyNoInteractions(iOservice, externalChannelService, pnEmdIntegrationClient);
-        Mockito.verify(timelineService, never()).addTimelineElement(Mockito.any(), Mockito.any(NotificationInt.class));
+        Mockito.verify(timelineUtils).buildCourtesyChannelFailedTimelineElement(
+                Mockito.eq(0), Mockito.eq(notification),
+                Mockito.eq(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP),
+                Mockito.eq(DeliveryModeInt.ANALOG), Mockito.eq(CourtesyChannelFailureReasonInt.EXPECTED_FAILURE), Mockito.anyString());
+        Mockito.verify(timelineService, times(1)).addTimelineElement(Mockito.any(), Mockito.any(NotificationInt.class));
     }
 
     @Test
@@ -441,7 +445,8 @@ class SendCourtesyMessageHandlerTest {
                 .thenReturn(Optional.of(courtesyChannelFailedElement(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP)));
 
         //WHEN
-        sendCourtesyMessageHandler.handleSendCourtesyMessageAction(iun, 0, details(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, DeliveryModeInt.ANALOG));
+        sendCourtesyMessageHandler.handleSendCourtesyMessageAction(iun, 0, detailsWithPlanned(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, DeliveryModeInt.ANALOG,
+                List.of(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS)));
 
         //THEN
         Mockito.verify(schedulerService, never()).scheduleEvent(Mockito.anyString(), Mockito.anyInt(), Mockito.any(Instant.class), Mockito.eq(ActionType.ANALOG_WORKFLOW));
@@ -468,10 +473,72 @@ class SendCourtesyMessageHandlerTest {
         Mockito.when(timelineService.getTimelineElementStrongly(iun, emailDeliveredId)).thenReturn(Optional.of(new TimelineElementInternal()));
 
         //WHEN
-        sendCourtesyMessageHandler.handleSendCourtesyMessageAction(iun, 0, details(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, DeliveryModeInt.ANALOG));
+        sendCourtesyMessageHandler.handleSendCourtesyMessageAction(iun, 0, detailsWithPlanned(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, DeliveryModeInt.ANALOG,
+                List.of(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.EMAIL)));
 
         //THEN
         Mockito.verify(schedulerService, never()).scheduleEvent(Mockito.anyString(), Mockito.anyInt(), Mockito.any(Instant.class), Mockito.eq(ActionType.ANALOG_WORKFLOW));
+    }
+
+    @Test
+    void handleSendCourtesyMessageActionAnalogAddressRemovedDuringRetryClosesChannelAndSchedulesAnalog() {
+        //GIVEN
+        NotificationRecipientInt recipient = getNotificationRecipientInt();
+        NotificationInt notification = getNotificationInt(recipient);
+        String iun = notification.getIun();
+
+        Mockito.when(notificationService.getNotificationByIun(iun)).thenReturn(notification);
+        Mockito.when(notificationUtils.getRecipientFromIndex(Mockito.any(NotificationInt.class), Mockito.anyInt())).thenReturn(recipient);
+        // l'indirizzo TPP è stato rimosso durante la finestra di retry: non è più tra gli indirizzi correnti
+        Mockito.when(addressBookService.getCourtesyAddress(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Collections.emptyList());
+        // l'esito appena scritto (TPP failed) è visibile in lettura strongly consistent
+        Mockito.when(timelineService.getTimelineElementStrongly(iun, courtesyChannelFailedId(iun, CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP)))
+                .thenReturn(Optional.of(courtesyChannelFailedElement(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP)));
+
+        // l'azione porta con sé l'insieme congelato al dispatch: solo TPP
+        SendCourtesyMessageActionDetails details = detailsWithPlanned(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP,
+                DeliveryModeInt.ANALOG, List.of(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP));
+
+        //WHEN
+        sendCourtesyMessageHandler.handleSendCourtesyMessageAction(iun, 0, details);
+
+        //THEN - il canale è chiuso con EXPECTED_FAILURE senza alcun invio e, essendo l'unico pianificato ormai chiuso, l'analogico viene schedulato
+        Mockito.verify(timelineUtils).buildCourtesyChannelFailedTimelineElement(
+                Mockito.eq(0), Mockito.eq(notification),
+                Mockito.eq(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP),
+                Mockito.eq(DeliveryModeInt.ANALOG), Mockito.eq(CourtesyChannelFailureReasonInt.EXPECTED_FAILURE), Mockito.anyString());
+        Mockito.verifyNoInteractions(iOservice, externalChannelService, pnEmdIntegrationClient);
+        Mockito.verify(schedulerService).scheduleEvent(Mockito.eq(iun), Mockito.eq(0), Mockito.any(Instant.class), Mockito.eq(ActionType.ANALOG_WORKFLOW));
+    }
+
+    @Test
+    void handleSendCourtesyMessageActionAnalogAddressAddedDuringRetryDoesNotBlockAnalog() {
+        //GIVEN
+        NotificationRecipientInt recipient = getNotificationRecipientInt();
+        NotificationInt notification = getNotificationInt(recipient);
+        String iun = notification.getIun();
+
+        Mockito.when(notificationService.getNotificationByIun(iun)).thenReturn(notification);
+        Mockito.when(notificationUtils.getRecipientFromIndex(Mockito.any(NotificationInt.class), Mockito.anyInt())).thenReturn(recipient);
+        // durante i retry viene aggiunto SMS: l'address book ora contiene TPP + SMS
+        Mockito.when(addressBookService.getCourtesyAddress(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(List.of(courtesyAddress(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP),
+                        courtesyAddress(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS)));
+        Mockito.when(pnEmdIntegrationClient.sendMessage(Mockito.any(SendMessageRequestBody.class))).thenReturn(tppPermanentFailure());
+        // solo l'esito di TPP è visibile; SMS non ha (né avrà) alcun esito perché non pianificato
+        Mockito.when(timelineService.getTimelineElementStrongly(iun, courtesyChannelFailedId(iun, CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP)))
+                .thenReturn(Optional.of(courtesyChannelFailedElement(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP)));
+
+        // insieme congelato al dispatch: solo TPP
+        SendCourtesyMessageActionDetails details = detailsWithPlanned(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP,
+                DeliveryModeInt.ANALOG, List.of(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP));
+
+        //WHEN
+        sendCourtesyMessageHandler.handleSendCourtesyMessageAction(iun, 0, details);
+
+        //THEN - il coordinamento considera solo i canali pianificati (TPP), non l'SMS aggiunto: l'analogico viene comunque schedulato
+        Mockito.verify(schedulerService).scheduleEvent(Mockito.eq(iun), Mockito.eq(0), Mockito.any(Instant.class), Mockito.eq(ActionType.ANALOG_WORKFLOW));
     }
 
     private static String courtesyChannelFailedId(String iun, CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT channel) {
@@ -513,6 +580,17 @@ class SendCourtesyMessageHandlerTest {
                 .channel(channel)
                 .retryIndex(retryIndex)
                 .deliveryMode(deliveryMode)
+                .plannedChannels(List.of(channel))
+                .build();
+    }
+
+    private static SendCourtesyMessageActionDetails detailsWithPlanned(CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT channel, DeliveryModeInt deliveryMode,
+                                                                       List<CourtesyDigitalAddressInt.COURTESY_DIGITAL_ADDRESS_TYPE_INT> plannedChannels) {
+        return SendCourtesyMessageActionDetails.builder()
+                .channel(channel)
+                .retryIndex(0)
+                .deliveryMode(deliveryMode)
+                .plannedChannels(plannedChannels)
                 .build();
     }
 

--- a/src/test/java/it/pagopa/pn/deliverypushworkflow/action/it/CourtesyMessageRetryTestIT.java
+++ b/src/test/java/it/pagopa/pn/deliverypushworkflow/action/it/CourtesyMessageRetryTestIT.java
@@ -305,6 +305,65 @@ class CourtesyMessageRetryTestIT extends CommonTestConfiguration {
         await().untilAsserted(() -> Assertions.assertTrue(timelineService.getTimelineElement(iun, scheduleAnalogWorkflowId(iun)).isPresent()));
     }
 
+    /**
+     * A courtesy address added during the retry window must not block the analog workflow. The expected set is frozen
+     * at dispatch (only TPP here); adding SMS afterwards must not make the coordination wait for a channel that was
+     * never dispatched. Without the fix the coordination would read the live addresses, see SMS "still open" and never
+     * schedule the analog workflow.
+     */
+    @Test
+    void analogAddressAddedDuringRetryDoesNotBlockAnalogWorkflow() {
+        NotificationInt notification = prepareNotification();
+        configureSingleRetry(COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP);
+        Mockito.doReturn(tppResponse(false)).when(pnEmdIntegrationClientMock).sendMessage(Mockito.any(SendMessageRequestBody.class));
+
+        // dispatch freezes the expected set to [TPP]
+        courtesyMessageUtils.scheduleCourtesyMessagesActions(notification, 0, DeliveryModeInt.ANALOG);
+
+        // an SMS courtesy address is added after dispatch: it is not part of the frozen set
+        addressBookMock.addCourtesyDigitalAddresses(INTERNAL_ID, PA_ID,
+                List.of(CourtesyDigitalAddressInt.builder().address("courtesy-SMS").type(COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS).build()));
+
+        String iun = notification.getIun();
+        awaitPresent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, false);
+        // the analog workflow is scheduled despite the SMS added mid-window
+        await().untilAsserted(() -> Assertions.assertTrue(timelineService.getTimelineElement(iun, scheduleAnalogWorkflowId(iun)).isPresent()));
+        // SMS was never dispatched: no courtesy events for it
+        assertAbsent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS, true);
+        assertAbsent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS, false);
+    }
+
+    /**
+     * A courtesy address removed during the retry window must not block the analog workflow: the channel, no longer
+     * resolvable, is closed with COURTESY_CHANNEL_FAILED so the frozen coordination set [SMS, TPP] still converges and
+     * the analog workflow starts. A permanent error is stubbed on the removed channel as a safety net in case its
+     * action runs before the removal (either ordering closes the channel).
+     */
+    @Test
+    void analogAddressRemovedDuringRetryDoesNotBlockAnalogWorkflow() {
+        NotificationInt notification = prepareNotification(COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS);
+        configureSingleRetry(COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS);
+        Mockito.doReturn(tppResponse(false)).when(pnEmdIntegrationClientMock).sendMessage(Mockito.any(SendMessageRequestBody.class));
+        Mockito.reset(externalChannelService);
+        applyToExternalChannelSend(Mockito.doThrow(permanentError()));
+
+        // dispatch freezes the expected set to [SMS, TPP]
+        courtesyMessageUtils.scheduleCourtesyMessagesActions(notification, 0, DeliveryModeInt.ANALOG);
+
+        // the SMS courtesy address is removed after dispatch
+        addressBookMock.addCourtesyDigitalAddresses(INTERNAL_ID, PA_ID, Collections.emptyList());
+
+        String iun = notification.getIun();
+        // both frozen channels are closed without success (SMS no longer resolvable, TPP permanent failure)
+        awaitPresent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS, false);
+        awaitPresent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, false);
+        // the analog workflow is scheduled despite the SMS removed mid-window
+        await().untilAsserted(() -> Assertions.assertTrue(timelineService.getTimelineElement(iun, scheduleAnalogWorkflowId(iun)).isPresent()));
+        // nothing was delivered
+        assertAbsent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.SMS, true);
+        assertAbsent(iun, COURTESY_DIGITAL_ADDRESS_TYPE_INT.TPP, true);
+    }
+
     // --- Helpers ---
 
     private org.mockito.stubbing.OngoingStubbing<SendMessageResponse> stubIo() {


### PR DESCRIPTION
…ing retries do not block the analog workflow

  - Carry the planned channels in the action details and propagate them on every reschedule
  - Close the channel with COURTESY_CHANNEL_FAILED when its address is no longer resolvable